### PR TITLE
Export GATT specs package as well

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,8 @@
                             org.sputnikdev.bluetooth,
                             org.sputnikdev.bluetooth.manager,
                             org.sputnikdev.bluetooth.manager.transport,
-                            org.sputnikdev.bluetooth.gattparser
+                            org.sputnikdev.bluetooth.gattparser,
+                            org.sputnikdev.bluetooth.gattparser.spec
                         </_exportcontents>
                     </instructions>
                     <niceManifest>true</niceManifest>


### PR DESCRIPTION
When implementing custom GATT parsers, one needs to access gatt specifications. This commit exports bluetooth-gatt-parser subpackage required to do so, so that custom parsers do not have to bundle their own.

Coupled with [bluetooth-gatt-parser/#7](https://github.com/sputnikdev/bluetooth-gatt-parser/pull/7)
