### PR TITLE
Fix: GattChannelHandler did not always listen to new binary change events

### DIFF
--- a/src/main/java/org/sputnikdev/esh/binding/bluetooth/handler/BluetoothHandler.java
+++ b/src/main/java/org/sputnikdev/esh/binding/bluetooth/handler/BluetoothHandler.java
@@ -107,6 +107,10 @@ class BluetoothHandler<T extends BluetoothGovernor> extends BaseThingHandler {
         });
     }
 
+    public boolean hasChannelHandler(ChannelHandler handler) {
+        return this.channelHandlers.containsKey(handler);
+    }
+
     @Override
     protected void updateState(String channelID, State state) {
         super.updateState(channelID, state);

--- a/src/main/java/org/sputnikdev/esh/binding/bluetooth/handler/GattChannelHandler.java
+++ b/src/main/java/org/sputnikdev/esh/binding/bluetooth/handler/GattChannelHandler.java
@@ -171,7 +171,7 @@ abstract class GattChannelHandler implements ChannelHandler {
     }
 
     private void buildMissingBinaryChannel() {
-        if (getBinaryChannel() == null) {
+        if (!handler.hasChannelHandler(this) || getBinaryChannel() == null) {
             Channel channel = buildBinaryChannel();
             handler.registerChannel(channel.getUID(), this);
             handler.updateThingWithChannels(Collections.singletonList(channel));


### PR DESCRIPTION
see https://github.com/sputnikdev/eclipse-smarthome-bluetooth-binding/issues/73#issuecomment-443533991 and https://github.com/sputnikdev/eclipse-smarthome-bluetooth-binding/issues/73#issuecomment-453755346

Signed-off-by: Patrick Fink <mail@pfink.de>